### PR TITLE
엉뚱한 region 에 CI 배포되는 거 고침

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,11 @@ jobs:
             mkdir ~/.aws
             echo -e "[default]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY\n" > ~/.aws/credentials
       - run:
+          name: Add AWS Profile Config
+          command: |
+            mkdir ~/.aws
+            echo -e "[default]\nregion=$AWS_DEFAULT_REGION\noutput=json\n" > ~/.aws/config
+      - run:
           name: Deploy
           command: bundle exec jets deploy production
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
           name: Install rsync
           command: sudo apt install rsync
       - run:
-          name: Add AWS Profile
+          name: Add AWS Profile Credentials
           command: |
             mkdir ~/.aws
             echo -e "[default]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY\n" > ~/.aws/credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,12 +109,18 @@ jobs:
           name: Add AWS Profile Credentials
           command: |
             mkdir ~/.aws
-            echo -e "[default]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY\n" > ~/.aws/credentials
+            echo -e "[default]\n\
+                     aws_access_key_id=$AWS_ACCESS_KEY_ID\n\
+                     aws_secret_access_key=$AWS_SECRET_ACCESS_KEY"\
+                     > ~/.aws/credentials
       - run:
           name: Add AWS Profile Config
           command: |
             mkdir ~/.aws
-            echo -e "[default]\nregion=$AWS_DEFAULT_REGION\noutput=json\n" > ~/.aws/config
+            echo -e "[default]\n\
+                     region=$AWS_DEFAULT_REGION\n\
+                     output=json"\
+                     > ~/.aws/config
       - run:
           name: Deploy
           command: bundle exec jets deploy production


### PR DESCRIPTION
### Issue

* CI 에서 aws profile 만들때, region 이 포함된 config 파일은 만들지 않음
* 이 때문에 region 이 설정되지 않아서, 임의의 region 인 us-east-1 에 배포됨

### Done

* profile 파일 만들어서 region 고정
* shall 스크립트에 행변환 `\n` 넣어서 가독성 향상