### PR TITLE
CI 에서 .aws 디렉토리가 중복되는 이슈 고침

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,12 @@ jobs:
           name: Use packages
           command: bundle --path vendor/bundle
       - run:
+          name: Set environment values for redis test
+          command: |
+            export REDIS_DB=$TEST_REDIS_DB
+            export REDIS_HOST=$TEST_REDIS_HOST
+            export REDIS_PORT=$TEST_REDIS_PORT
+      - run:
           name: Run tests
           command: DISABLE_SPRING=true bundle exec rspec
           when: always
@@ -116,6 +122,13 @@ jobs:
                      region=$AWS_DEFAULT_REGION\n\
                      output=json"\
                      > ~/.aws/config
+      - run:
+          name: Set environment values for redis production
+          command: |
+            export REDIS_DB=$PRODUCTION_REDIS_DB
+            export REDIS_HOST=$PRODUCTION_REDIS_HOST
+            export REDIS_PORT=$PRODUCTION_REDIS_PORT
+            export REDIS_PASSWORD=$PRODUCTION_REDIS_PASSWORD
       - run:
           name: Deploy
           command: bundle exec jets deploy production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,9 +106,11 @@ jobs:
           name: Install rsync
           command: sudo apt install rsync
       - run:
+          name: Create Directory for AWS Profile
+          command: mkdir ~/.aws
+      - run:
           name: Add AWS Profile Credentials
           command: |
-            mkdir ~/.aws
             echo -e "[default]\n\
                      aws_access_key_id=$AWS_ACCESS_KEY_ID\n\
                      aws_secret_access_key=$AWS_SECRET_ACCESS_KEY"\
@@ -116,7 +118,6 @@ jobs:
       - run:
           name: Add AWS Profile Config
           command: |
-            mkdir ~/.aws
             echo -e "[default]\n\
                      region=$AWS_DEFAULT_REGION\n\
                      output=json"\

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,7 @@ defaults: &defaults
   working_directory: ~/PongDang-API
   docker:
     - image: circleci/ruby:2.5.3
-      environment:
-        RAILS_ENV: test
     - image: circleci/redis:latest
-      environment:
-        REDIS_DB: 11
-        REDIS_HOST: 127.0.01
-        REDIS_PORT: 6379
 version: 2
 jobs:
   checkout code:


### PR DESCRIPTION
### Issue
* `mkdir .aws` 가 두번 있어서 [파일 중복 에러 발생](https://app.circleci.com/jobs/github/say8425/PongDang-API/154/parallel-runs/0/steps/0-107)
* redis 배포시, 사용되는 env 가 무조건 circle ci 콘솔에 설정된 env 를 사용하고 있음

### Done

* 아예 `.aws` 생성을 별도의 job 으로 빼줌
* production 용 test 용 따로 만들어서, 그때그때 갈아끼워줌

### Todo

* env 레포지 적용